### PR TITLE
[PR] ✨ Fixed Dvorak Keyboard Layout Blocked Keys

### DIFF
--- a/src/hooks/useKeys.ts
+++ b/src/hooks/useKeys.ts
@@ -1,11 +1,15 @@
 import { useCallback, useEffect, useState } from "react";
+import { dvorakMap, qwertyMap } from '../lib/layouts';
 
-function isKeyAllowed(code: string) {
+function isKeyAllowed(code: string, k: string) {
+  const corresponding = dvorakMap[k];
+  const allowed = Object.keys(qwertyMap);
   return (
     code.startsWith("Key") ||
     code.startsWith("Digit") ||
     code === "Backspace" ||
-    code === "Space"
+    code === "Space" ||
+    allowed.includes(corresponding)
   );
 }
 
@@ -16,7 +20,7 @@ export default function useKeys(enabled: boolean) {
 
   const keydownHandler = useCallback(
     ({ key, code }: KeyboardEvent) => {
-      if (!enabled || !isKeyAllowed(code)) {
+      if (!enabled || !isKeyAllowed(code, key)) {
         return;
       }
 

--- a/src/hooks/useTypingTest.ts
+++ b/src/hooks/useTypingTest.ts
@@ -34,7 +34,7 @@ export default function useTypingTest() {
 
   useEffect(() => {
     if (!timeLeft && state === "run") {
-      console.log("Time's up");
+      console.log("[useTypingTest/timeLeft]: Time's up!");
       setState("end");
       sumErrors();
     }

--- a/src/hooks/useWords.ts
+++ b/src/hooks/useWords.ts
@@ -2,10 +2,8 @@ import { faker } from "@faker-js/faker";
 import { useCallback, useState } from "react";
 
 function generateWords(count: number) {
-      // This is deprecated, but I like the words it generates better.
-      return faker.random.words(count).toLowerCase()
       // This is the new way to generate words.
-      // return faker.word.words(count).toLowerCase();
+      return faker.word.words(count).toLowerCase();
 }
 
 export default function useWords(count: number) {

--- a/src/lib/layouts.ts
+++ b/src/lib/layouts.ts
@@ -1,0 +1,15 @@
+// shoutout to: https://github.com/kentonv/dvorak-qwerty/blob/1819148d8497a1989e87349d083f723659d0b9e6/unix/xdq.c#L117
+const qwertyLayout = "-=qwertyuiop[]asdfghjkl;'zxcvbnm,./";
+const dvorakLayout = "[]',.pyfgcrl/=aoeuidhtns-;qjkxbmwvz";
+
+const createLayoutMap = (layout: string) => {
+      const map = qwertyLayout.split("").reduce((acc, key, index) => {
+            acc[key] = layout[index];
+            return acc;
+      }
+      , {} as Record<string, string>);
+      return map;
+};
+
+export const qwertyMap = createLayoutMap(qwertyLayout);
+export const dvorakMap = createLayoutMap(dvorakLayout);


### PR DESCRIPTION
This PR fixes #4

I added a layout mapping from: [this OSS repo](https://github.com/kentonv/dvorak-qwerty/blob/1819148d8497a1989e87349d083f723659d0b9e6/unix/xdq.c#L117)

```js
const qwertyLayout = "-=qwertyuiop[]asdfghjkl;'zxcvbnm,./";
const dvorakLayout = "[]',.pyfgcrl/=aoeuidhtns-;qjkxbmwvz";
```

I also extended the check for the typed key being within these char arrays/strings.
```js
function isKeyAllowed(code: string, k: string) {
  const corresponding = dvorakMap[k];
  const allowed = Object.keys(qwertyMap);
  return (
    code.startsWith("Key") ||
    code.startsWith("Digit") ||
    code === "Backspace" ||
    code === "Space"
    allowed.includes(corresponding)
  );
}
```

Cheers! 🚀